### PR TITLE
Update zabbix_container.conf

### DIFF
--- a/zabbix_container.conf
+++ b/zabbix_container.conf
@@ -1,3 +1,4 @@
 UserParameter=ct.memory.size[*],free -b | awk '$ 1 == "Mem:" {total=$ 2; used=($ 3+$ 5); pused=(($ 3+$ 5)*100/$ 2); free=$ 4; pfree=($ 4*100/$ 2); shared=$ 5; buffers=$ 6; cache=$ 6; available=($ 6+$ 7); pavailable=(($ 6+$ 7)*100/$ 2); if("$1" == "") {printf("%.0f", total )} else {printf("%.0f", $1 "" )} }'
 UserParameter=ct.swap.size[*],free -b | awk '$ 1 == "Swap:" {total=$ 2; used=$ 3; free=$ 4; pfree=($ 4*100/$ 2); pused=($ 3*100/$ 2); if("$1" == "") {printf("%.0f", free )} else {printf("%.0f", $1 "" )} }'
 UserParameter=ct.cpu.load[*],uptime | awk -F'[, ]+' '{avg1=$(NF-2); avg5=$(NF-1); avg15=$(NF)}{print $2/'$(nproc)'}'
+UserParameter=ct.uptime,cut -d"." -f1 /proc/uptime


### PR DESCRIPTION
system.uptime from zabbix-agent is wrong too : it reports uptime from the host, not from the container itself.
uptime command and /proc/uptime are right inside the container, so adding a user parameter to rely on them instead.
Will need to update Template Linux Container.