### PR TITLE
Update zabbix_container.conf

### DIFF
--- a/zabbix_container.conf
+++ b/zabbix_container.conf
@@ -1,4 +1,4 @@
-UserParameter=ct.memory.size[*],free -b | awk '$ 1 == "Mem:" {total=$ 2; used=($ 3+$ 5); pused=(($ 3+$ 5)*100/$ 2); free=$ 4; pfree=($ 4*100/$ 2); shared=$ 5; buffers=$ 6; cached=$ 6; available=$ 7; pavailable=($ 7*100/$ 2); if("$1" == "") {printf("%.0f", total )} else {printf("%.0f", $1 "" )} }'
-UserParameter=ct.swap.size[*],free -b | awk '$ 1 == "Swap:" {total=$ 2; used=$ 3; free=$ 4; pfree=($ 4*100/$ 2); pused=($ 3*100/$ 2); if("$1" == "") {printf("%.0f", free )} else {printf("%.0f", $1 "" )} }'
-UserParameter=ct.cpu.load[*],uptime | awk -F'[, ]+' '{avg1=$(NF-2); avg5=$(NF-1); avg15=$(NF)}{print $2/'$(nproc)'}'
+UserParameter=ct.memory.size[*],free -b | awk 'NR==2 {total=$ 2; used=($ 3+$ 5); pused=(($ 3+$ 5)*100/$ 2); free=$ 4; pfree=($ 4*100/$ 2); shared=$ 5; buffers=$ 6; cached=$ 6; available=$ 7; pavailable=($ 7*100/$ 2); if("$1" == "") {printf("%.0f", total )} else {printf("%.0f", $1 "" )} }'
+UserParameter=ct.swap.size[*],free -b | awk 'NR==3 {total=$ 2; used=$ 3; free=$ 4; pfree=($ 4*100/$ 2); pused=($ 3*100/$ 2); if("$1" == "") {printf("%.0f", free )} else {printf("%.0f", $1 "" )} }'
+UserParameter=ct.cpu.load[*],cut -d" " -f1-3 /proc/loadavg | awk -F'[, ]+' '{avg1=$(NF-2); avg5=$(NF-1); avg15=$(NF)}{print $2/'$(nproc)'}'
 UserParameter=ct.uptime,cut -d"." -f1 /proc/uptime


### PR DESCRIPTION
- Updated ct.memory.size and ct.swap.size to use coordinates instead of strings to match non english os.
- Updated ct.cpu.load to use /proc/loadavg so it'll retrieve the avg load times in the correct format (also non english os related issue)